### PR TITLE
Improve desktop port usability

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,18 @@
+# Desktop Port
+
+This folder contains Processing sketches ported from the Android version so they can
+be run on a regular desktop JVM. Use the provided `run.sh` script to compile and
+execute any of the sketches.
+
+```
+./run.sh [full.class.Name]
+```
+
+If no class name is supplied, the classic `DrawStickFigureAnimDesktop` sketch is
+started. To run the launch animation, pass its class name:
+
+```
+./run.sh processing.test.draw_stick_figure_anim.desktop.LaunchAnimationDesktop
+```
+
+The script requires a local Java JDK and the Processing core library (`core.jar`).

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -e
-# Simple script to compile and run the desktop version of the launch animation
+# Simple script to compile and run the desktop version of the animations
 BASEDIR=$(dirname "$0")
 SRC_DIR="$BASEDIR/src"
 LIB="$BASEDIR/core.jar"
 OUT_DIR="$BASEDIR/out"
 mkdir -p "$OUT_DIR"
 javac -classpath "$LIB" -d "$OUT_DIR" $(find "$SRC_DIR" "$BASEDIR/../app/src/main/java/Util" "$BASEDIR/../app/src/main/java/drawableObjects" -name '*.java')
-java -classpath "$OUT_DIR":"$LIB" processing.test.draw_stick_figure_anim.desktop.DrawStickFigureAnimDesktop
+
+# Allow selecting which PApplet to run. Defaults to DrawStickFigureAnimDesktop
+MAIN_CLASS=${1:-processing.test.draw_stick_figure_anim.desktop.DrawStickFigureAnimDesktop}
+java -classpath "$OUT_DIR":"$LIB" "$MAIN_CLASS"

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,7 @@
 Android app that allows a user to create stick figure animations similar to pivot on desktop.
 
+## Desktop version
+
+A lightweight desktop port is available in the `desktop/` folder. See
+`desktop/README.md` for compilation and execution instructions.
+


### PR DESCRIPTION
## Summary
- update desktop `run.sh` to allow choosing which sketch to run
- document desktop build instructions in a new README
- reference desktop port from root README

## Testing
- `bash -c 'BASEDIR=desktop; LIB="$BASEDIR/core.jar"; OUT="$BASEDIR/out_test"; mkdir -p "$OUT"; javac -classpath "$LIB" -d "$OUT" $(find "$BASEDIR/src" "$BASEDIR/../app/src/main/java/Util" "$BASEDIR/../app/src/main/java/drawableObjects" -name \*.java) && echo "compile ok"'

------
https://chatgpt.com/codex/tasks/task_e_6875684ef510832b9e6655388411c6c2