### PR TITLE
Desktop menu and entry points

### DIFF
--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -6,5 +6,6 @@ SRC_DIR="$BASEDIR/src"
 LIB="$BASEDIR/core.jar"
 OUT_DIR="$BASEDIR/out"
 mkdir -p "$OUT_DIR"
-javac -classpath "$LIB" -d "$OUT_DIR" $(find "$SRC_DIR" "$BASEDIR/../app/src/main/java/Util" "$BASEDIR/../app/src/main/java/drawableObjects" -name '*.java')
-java -classpath "$OUT_DIR":"$LIB" processing.test.draw_stick_figure_anim.desktop.DrawStickFigureAnimDesktop
+javac -classpath "$LIB" -d "$OUT_DIR" $(find "$SRC_DIR" -name '*.java')
+# Launch the desktop animation entry point
+java -classpath "$OUT_DIR":"$LIB" processing.test.draw_stick_figure_anim.desktop.LaunchAnimationDesktop

--- a/desktop/src/Util/Drawer.java
+++ b/desktop/src/Util/Drawer.java
@@ -1,0 +1,91 @@
+package Util;
+
+import java.util.ArrayList;
+
+import DrawableObjects.StickFigure;
+import processing.core.PApplet;
+
+/**
+ * Created by neema boutorabi on 2016-08-24.
+ */
+public class Drawer {
+
+    //PApplet used to draw objects onto the screen
+    private PApplet pApplet;
+
+    public Drawer(PApplet pApplet){
+
+        this.pApplet = pApplet;
+
+    }
+
+    /**
+     * Method to draw a stick figure onto the screen
+     *
+     * All the dimensions for the stick figure should be set before this is called
+     *
+     * @param stickFigure
+     */
+    public void drawStickFigure(StickFigure stickFigure){
+
+        ArrayList<StickFigure.BodyPart>  bodyParts = (ArrayList<StickFigure.BodyPart>) stickFigure.getBodyParts();
+
+        pApplet.fill(0);
+
+        for(int i = 0; i < bodyParts.size(); i++){
+            if(bodyParts.get(i) instanceof StickFigure.LineComponent){
+                pApplet.stroke(0);
+                pApplet.strokeWeight(20);
+                StickFigure.LineComponent lc = (StickFigure.LineComponent) bodyParts.get(i);
+                pApplet.line((int) lc.getxStart(), (int) lc.getyStart(), (int) lc.getxEnd(), (int) lc.getyEnd());
+
+            }else if(bodyParts.get(i) instanceof StickFigure.Head){
+
+                StickFigure.Head h = (StickFigure.Head) bodyParts.get(i);
+                pApplet.ellipse((int) h.getxCenter(), (int) h.getyCenter(), (int) h.getSize(), (int) h.getSize());
+            }
+        }
+
+
+    }
+
+    public void clearRegion(double x1, double x2, double y1, double y2, ColorVector cv ){
+
+        pApplet.fill(cv.R(), cv.G(), cv.B());
+        pApplet.noStroke();
+        pApplet.rect((float) x1, (float) y1, (float) x2, (float) y2);
+
+    }
+
+
+    public static class ColorVector {
+        private int R;
+        private int G;
+        private int B;
+
+        public ColorVector(int R, int G, int B){
+            this.R = R;
+            this.G = G;
+            this.B = B;
+        }
+
+        public ColorVector(int val){
+            this.R = val;
+            this.G = val;
+            this.B = val;
+        }
+
+        public int R(){
+            return R;
+        }
+
+        public int G(){
+            return G;
+        }
+
+        public int B(){
+            return B;
+        }
+    }
+
+}

--- a/desktop/src/Util/MathUtil.java
+++ b/desktop/src/Util/MathUtil.java
@@ -1,0 +1,117 @@
+package Util;
+
+/**
+ * Created by neema on 2016-08-31.
+ *
+ * Utility class for math functions and calculations
+ */
+public class MathUtil {
+
+
+    /**
+     * This method determines the shortest distance from a point to a line segment
+     *
+     * Algorithm :
+     *
+     * 1) Construct an orthogonal vector to the line segment
+     * 2) Check to see if a line with this vector direction originating from the point will intersect our line segment
+     * 3) If yes then the distance of this orthogonal line is the shortest distance
+     * 4) If not, measure the distance between the point and both the start and end co-ordinates of the line segment
+     * 5) Return the smallest of these two values
+     *
+     *
+     * @param xStart
+     *              x co-ordinate of start of line segment
+     * @param xEnd
+     *              x co-ordinate of end of line segment
+     * @param yStart
+     *              y co-ordinate of start of line segment
+     * @param yEnd
+     *              y co-ordinate of end of line segment
+     * @param x
+     *              x co-ordinate of point
+     * @param y
+     *              y co-ordinate of point
+     * @return
+     *              shortest distance in pixels
+     */
+    public static double shortestDistanceToLine(double xStart, double xEnd, double yStart, double yEnd, double x, double y) {
+
+        //initialize distance 1 to highest possible value
+        double distance1 = Integer.MAX_VALUE;
+        double distance2;
+        double distance3;
+
+        //check if line segment is vertical or horizontal
+        if (Math.abs(xEnd - xStart) > 0.01 && Math.abs(yEnd - yStart) > 0.01) {
+
+            double a = xEnd - xStart;
+            double b = yEnd - yStart;
+            double c = -((Math.pow(a, 2)) / b);
+
+            //t is the free parameter for our line from the point to the line
+            double t = (xStart - (a / b) * yStart - x + y) / (a - c * (a / b));
+
+            //s is the free parameter for the line containing the line segment
+            double s = ((t * (a) + x - xStart) / (a));
+
+            //if there is an intersection then our value for s must be between 0 and 1
+            if (s > 0.0 && s < 1.0) {
+                double intersectX = s * a + xStart;
+                double intersectY = s * b + yStart;
+
+                //get distance from point to intersect
+                distance1 = getDistance(x, y, intersectX, intersectY);
+
+            }
+            //line is vertical, orthogonal distance to line is simply the difference in x co-ordinates
+        }else if (Math.abs(xEnd - xStart) <= 0.01){
+            if(yEnd > yStart){
+                //check if point lies between starting and ending y co-ordinates of line
+                if(y <= yEnd && y >= yStart){
+                    distance1 = Math.abs(xEnd - x);
+                }
+            }else{
+                //check if point lies between ending and starting y co-ordinates of line
+                if(y <= yStart && y >= yEnd){
+                    distance1 = Math.abs(xEnd - x);
+                }
+            }
+            //line is horizontal, orthogonal distance to line is simply the difference in y co-ordinates
+        }else if (Math.abs(yEnd - yStart) <= 0.01){
+            if(xEnd > xStart){
+                //check if point lies between starting and ending x co-ordinates of line
+                if(x <= xEnd && x >= xStart){
+                    distance1 = Math.abs(yEnd - y);
+                }
+            }else{
+                //check if point lies between ending and starting x co-ordinates of line
+                if(x <= xStart && x >= xEnd){
+                    distance1 = Math.abs(yEnd - y);
+                }
+            }
+        }
+
+        //get distance from point to end of line
+        distance2 = getDistance(x, y, xEnd, yEnd);
+        //get distance from point to start of line
+        distance3 = getDistance(x, y, xStart, yStart);
+            
+            
+        double shortestDistance = Math.min(distance1, distance2);
+        shortestDistance = Math.min(shortestDistance, distance3);
+
+        System.out.println(shortestDistance);
+            
+        return shortestDistance;
+
+
+    }
+    
+    //returns euclidean distance between two points
+
+    public static double getDistance(double x1, double y1, double x2, double y2){
+
+        return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+    }
+}

--- a/desktop/src/drawableObjects/StickFigure.java
+++ b/desktop/src/drawableObjects/StickFigure.java
@@ -1,0 +1,232 @@
+package DrawableObjects;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import Util.MathUtil;
+
+/**
+ * Created by neema boutorabi on 2016-08-23.
+ *
+ * This class represents a standardised stick figure object, this will be utilized in the launch
+ * screen and the activity designer section of the app
+ */
+public class StickFigure{
+
+    //group together all drawable body parts in a list
+    private List<BodyPart> bodyParts;
+
+    //list of points that the user can interact with to move their stick figure
+    private List<InteractivePoint> interactivePoints;
+
+    private double xCenter;
+    private double yCenter;
+
+    private Head head;
+    private LineComponent spine;
+    private LineComponent upperArm1;
+    private LineComponent upperArm2;
+    private LineComponent lowerArm1;
+    private LineComponent lowerArm2;
+    private LineComponent upperLeg1;
+    private LineComponent upperLeg2;
+    private LineComponent lowerLeg1;
+    private LineComponent lowerLeg2;
+
+    /**
+        Constructor for this class
+
+        the only parameters that need to be specified are the
+        xCenter and yCenter variables, every other item is drawn relative to these values
+
+     **/
+
+    public StickFigure(double xCenter, double yCenter) {
+
+        this.xCenter = xCenter;
+        this.yCenter = yCenter;
+
+        //all of the stick figure dimensions will be calculated according to this value
+        double size = 350;
+
+        this.spine = new LineComponent(xCenter, yCenter - size/2 , xCenter, yCenter + size/2);
+
+
+        this.head = new Head(xCenter, yCenter - (size / 2 + size / 7.5), size / 3.75);
+
+
+        this.upperArm1 = new LineComponent(xCenter, yCenter - size/6 , xCenter + size/6 , yCenter);
+        this.upperArm2 = new LineComponent(xCenter, yCenter - size/6, xCenter - size/6, yCenter);
+        this.lowerArm1 = new LineComponent(upperArm1.getxEnd(), upperArm1.getyEnd(), upperArm1.getxEnd() + size/6, upperArm1.getyEnd() + size/6);
+        this.lowerArm2 = new LineComponent(upperArm2.getxEnd(), upperArm2.getyEnd(), upperArm2.getxEnd() - size/6, upperArm2.getyEnd() + size/6);
+        this.upperLeg1 = new LineComponent(xCenter, yCenter + size/2, xCenter + size/5.45, yCenter + size/1.46);
+        this.upperLeg2 = new LineComponent(xCenter, yCenter + size/2, xCenter - size/5.45, yCenter + size/1.46);
+        this.lowerLeg1 = new LineComponent(upperLeg1.getxEnd(), upperLeg1.getyEnd(), upperLeg1.getxEnd() + size/5.45, upperLeg1.getyEnd() + size/5.45);
+        this.lowerLeg2 = new LineComponent(upperLeg2.getxEnd(), upperLeg2.getyEnd(), upperLeg2.getxEnd() - size/5.45, upperLeg2.getyEnd() + size/5.45);
+
+        bodyParts = new ArrayList<BodyPart>();
+        interactivePoints = new ArrayList<InteractivePoint>();
+
+        //the order in which these objects are added matters since some of their dimensions depend on one another
+
+        bodyParts.add(spine);
+        bodyParts.add(head);
+        bodyParts.add(upperArm1);
+        bodyParts.add(upperArm2);
+        bodyParts.add(upperLeg1);
+        bodyParts.add(upperLeg2);
+        bodyParts.add(lowerLeg1);
+        bodyParts.add(lowerLeg2);
+        bodyParts.add(lowerArm1);
+        bodyParts.add(lowerArm2);
+
+    }
+
+    public List<BodyPart> getBodyParts (){
+
+        return this.bodyParts;
+    }
+
+    /**
+     * This method is called when the user touches the screen, the return value represents whether the user
+     * clicked on the stick figure or not
+     *
+     *
+     * @param mouseX
+     *              The x position of the touch event
+     * @param mouseY
+     *              The y position of the touch event
+     *
+     *
+     */
+    public boolean wasTouched(int mouseX, int mouseY){
+
+        //iterate through all body parts and check if any of them were touched
+        for(BodyPart bp : bodyParts){
+            if(bp.wasTouched(mouseX, mouseY)){
+                return true;
+            }
+        }
+
+        return false;
+
+    }
+
+    //All body parts implement this interface, this is mainly here for code readability
+    public interface BodyPart {
+
+       public boolean wasTouched(int mouseX, int mouseY);
+
+    }
+
+    //all parts of the stick figure that are lines fall into this category
+    //e.g arms and legs
+    public static class LineComponent implements BodyPart {
+
+        private double xStart;
+        private double xEnd;
+
+        private double yStart;
+        private double yEnd;
+
+        public LineComponent(double xStart, double yStart, double xEnd, double yEnd){
+            this.xStart = xStart;
+            this.yStart = yStart;
+            this.xEnd = xEnd;
+            this.yEnd = yEnd;
+        }
+
+        @Override
+        public boolean wasTouched(int mouseX, int mouseY){
+
+            //get the shortest distance from the point to this line segment
+            double distance = MathUtil.shortestDistanceToLine(xStart, xEnd, yStart, yEnd, mouseX, mouseY);
+
+            //check if distance is below threshold
+            if(distance <= 40){
+                return true;
+            }else {
+
+                return false;
+            }
+        }
+
+        public double getxStart() {
+            return this.xStart;
+        }
+
+        public double getyStart() {
+            return this.yStart;
+        }
+
+        public double getxEnd() {
+            return this.xEnd;
+        }
+
+        public double getyEnd() {
+            return this.yEnd;
+        }
+
+
+
+    }
+
+    //This represents the stick figures head
+    public static class Head implements BodyPart  {
+
+        double xCenter;
+        double yCenter;
+        double size;
+
+        public Head (double xCenter, double yCenter, double size){
+
+            this.xCenter = xCenter;
+            this.yCenter = yCenter;
+            this.size = size;
+        }
+
+        public double getxCenter(){
+            return xCenter;
+        }
+
+        public double getyCenter(){
+            return yCenter;
+        }
+
+        public double getSize(){
+            return size;
+        }
+
+        public boolean wasTouched(int mouseX, int mouseY){
+
+            //get radial distance from center of head to point of touch event
+            double distance = MathUtil.getDistance(xCenter, yCenter, mouseX, mouseY);
+
+            //take away radius of head and check if remaining distance is below threshold
+            if((distance - size/2) < 20){
+                return true;
+            }else {
+                return false;
+            }
+        }
+
+    }
+
+    //represents a point of interaction that allows the user to move parts of the stick figure
+    private static class InteractivePoint {
+
+        double xCenter;
+        double yCenter;
+        double size;
+
+        public InteractivePoint(double xCenter, double yCenter, double size){
+            this.xCenter = xCenter;
+            this.yCenter = yCenter;
+            this.size = size;
+
+        }
+
+    }
+
+
+}

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/DrawStickFigureAnimDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/DrawStickFigureAnimDesktop.java
@@ -158,7 +158,8 @@ public class DrawStickFigureAnimDesktop extends PApplet {
 
   }
   public void settings() {
-    size(1080, 1920); // Fixed size for desktop
+    // Use landscape orientation when running on the desktop
+    size(1920, 1080);
   }
 
   static public void main(String[] passedArgs) {

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/LaunchAnimationDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/LaunchAnimationDesktop.java
@@ -2,6 +2,7 @@ package processing.test.draw_stick_figure_anim.desktop;
 
 import DrawableObjects.StickFigure;
 import Util.Drawer;
+import processing.test.draw_stick_figure_anim.desktop.MenuSketchDesktop;
 import processing.core.PApplet;
 import processing.core.PFont;
 
@@ -86,6 +87,7 @@ public class LaunchAnimationDesktop extends PApplet {
         }
 
         if((millis() - startTime) > 8000){
+            PApplet.main(MenuSketchDesktop.class.getName());
             exit();
         }
     }
@@ -145,7 +147,8 @@ public class LaunchAnimationDesktop extends PApplet {
     }
 
     public void settings() {
-        size(1080, 1920);
+        // Desktop version runs in landscape mode
+        size(1920, 1080);
     }
 
     public static void main(String[] args) {

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/MainActivityDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/MainActivityDesktop.java
@@ -1,0 +1,11 @@
+package processing.test.draw_stick_figure_anim.desktop;
+
+/**
+ * Entry point replicating the Android MainActivity.
+ * Starts the launch animation in landscape mode.
+ */
+public class MainActivityDesktop {
+    public static void main(String[] args) {
+        LaunchAnimationDesktop.main(args);
+    }
+}

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/MenuActivityDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/MenuActivityDesktop.java
@@ -1,0 +1,10 @@
+package processing.test.draw_stick_figure_anim.desktop;
+
+/**
+ * Minimal replacement for the Android MenuActivity.
+ */
+public class MenuActivityDesktop {
+    public static void main(String[] args) {
+        MenuSketchDesktop.main(args);
+    }
+}

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/MenuSketchDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/MenuSketchDesktop.java
@@ -1,0 +1,36 @@
+package processing.test.draw_stick_figure_anim.desktop;
+
+import processing.core.PApplet;
+
+/**
+ * Simple desktop sketch representing the main menu.
+ * Clicking anywhere launches the stick figure animation.
+ */
+public class MenuSketchDesktop extends PApplet {
+
+    public void setup() {
+        textAlign(CENTER, CENTER);
+        textSize(64);
+        background(255);
+        fill(0);
+        text("Menu", width/2f, height/2f);
+    }
+
+    public void draw() {
+        // nothing animated here
+    }
+
+    public void mousePressed() {
+        // start the drawing sketch when the user clicks
+        PApplet.main(DrawStickFigureAnimDesktop.class.getName());
+        exit();
+    }
+
+    public void settings() {
+        size(1920, 1080);
+    }
+
+    public static void main(String[] args) {
+        PApplet.main(MenuSketchDesktop.class.getName());
+    }
+}

--- a/desktop/src/processing/test/draw_stick_figure_anim/desktop/MyApplicationDesktop.java
+++ b/desktop/src/processing/test/draw_stick_figure_anim/desktop/MyApplicationDesktop.java
@@ -1,0 +1,11 @@
+package processing.test.draw_stick_figure_anim.desktop;
+
+/**
+ * Placeholder class matching the Android application's entry point.
+ * For the desktop version this simply launches the animation.
+ */
+public class MyApplicationDesktop {
+    public static void main(String[] args) {
+        LaunchAnimationDesktop.main(args);
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,17 @@
 Android app that allows a user to create stick figure animations similar to pivot on desktop.
 
+## Desktop version
+
+A standalone desktop port lives in the `desktop` directory. The desktop source
+tree mirrors the structure of the Android app with simplified replacements for
+the activities. All sketches run in **landscape** mode (1920x1080). To try it
+out run:
+
+```bash
+cd desktop
+./run.sh
+```
+This will compile the desktop sources and start the launch animation.
+After the splash screen a simple menu appears from which the stick
+figure animation can be launched.
+


### PR DESCRIPTION
## Summary
- add simple desktop menu sketch
- launch menu after splash screen
- provide desktop equivalents of Android entry classes
- document desktop flow with menu

## Testing
- `bash gradlew --version` *(fails: Could not determine java version from '21.0.7')*
- `bash desktop/run.sh` *(fails: Cannot run sketch without a display)*
- `javac -classpath desktop/core.jar -d /tmp/out $(find desktop/src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_68758dd6d490832baaf5e537c415ed61